### PR TITLE
feat(banner): integrate ribbon component using TDD

### DIFF
--- a/src/components/Banner/__snapshots__/test.tsx.snap
+++ b/src/components/Banner/__snapshots__/test.tsx.snap
@@ -69,6 +69,10 @@ exports[`<Banner /> should render the heading 1`] = `
   font-weight: 600;
 }
 
+@media (max-width:1170px) {
+
+}
+
 @media (min-width:768px) {
   .c0 {
     box-shadow: 0 0.4rem 0.5rem 0 rgba(0,0,0,0.2);

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -1,4 +1,5 @@
 import Button from 'components/Button'
+import Ribbon, { RibbonColors, RibbonSizes } from 'components/Ribbon'
 
 import * as S from './styles'
 
@@ -8,6 +9,9 @@ export type BannerProps = {
   subtitle?: string
   buttonLabel?: string
   buttonLink?: string
+  ribbonLabel?: string
+  ribbonSize?: RibbonSizes
+  ribbonColor?: RibbonColors
 }
 
 const Banner = ({
@@ -15,10 +19,20 @@ const Banner = ({
   title,
   subtitle,
   buttonLabel,
-  buttonLink
+  buttonLink,
+  ribbonLabel,
+  ribbonSize = 'normal',
+  ribbonColor = 'primary'
 }: BannerProps) => (
   <S.Wrapper>
+    {!!ribbonLabel && (
+      <Ribbon size={ribbonSize} color={ribbonColor}>
+        {ribbonLabel}
+      </Ribbon>
+    )}
+
     <S.Image src={img} role="img" aria-label={title} />
+
     <S.Caption>
       <S.Title>{title}</S.Title>
       <S.Subtitle dangerouslySetInnerHTML={{ __html: subtitle! }} />

--- a/src/components/Banner/stories.tsx
+++ b/src/components/Banner/stories.tsx
@@ -1,9 +1,15 @@
 import { Meta, StoryFn } from '@storybook/react'
+
 import Banner, { BannerProps } from '.'
 
 export default {
   title: 'components/Banner',
   component: Banner,
+  argTypes: {
+    ribbonLabel: {
+      type: 'string'
+    }
+  },
   args: {
     img: 'https://img.freepik.com/fotos-gratis/renderizacao-3d-de-fundo-de-textura-hexagonal_23-2150796421.jpg?t=st=1744305474~exp=1744309074~hmac=21ca4e3043d63d9d289c195d50fbfca592080b8dad64dd27e9d56cf8be53d360&w=996',
     title: 'Defy death',
@@ -16,4 +22,14 @@ export default {
   }
 } as Meta
 
-export const Default: StoryFn<BannerProps> = (args) => <Banner {...args} />
+export const Default: StoryFn<BannerProps> = (args) => (
+  <div style={{ maxWidth: '104rem', margin: '0 auto' }}>
+    <Banner {...args} />
+  </div>
+)
+
+export const WithRibbon: StoryFn<BannerProps> = (args) => (
+  <div style={{ maxWidth: '104rem', margin: '0 auto' }}>
+    <Banner {...args} ribbonLabel="50% OFF" />
+  </div>
+)

--- a/src/components/Banner/styles.ts
+++ b/src/components/Banner/styles.ts
@@ -1,12 +1,24 @@
 import styled, { css } from 'styled-components'
 import media from 'styled-media-query'
 
+import * as RibbonStyles from 'components/Ribbon/styles'
+
 type ImageProps = {
   src?: string
 }
 
 export const Wrapper = styled.main`
   position: relative;
+
+  ${media.lessThan('large')`
+      ${RibbonStyles.Wrapper}  {
+      right: 0;
+
+      &::before {
+        display: none;
+      }
+    }
+    `}
 
   ${media.greaterThan('medium')`
     box-shadow: 0 0.4rem 0.5rem 0 rgba(0, 0, 0, 0.2);

--- a/src/components/Banner/test.tsx
+++ b/src/components/Banner/test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react'
 
+import { renderWithTheme } from 'utils/tests/helpers'
 import Banner from '.'
-import { renderWithTheme } from '@/utils/tests/helpers'
 
 const props = {
   img: 'https://imagemDeMock.com.br',
@@ -26,5 +26,22 @@ describe('<Banner />', () => {
     expect(screen.getByRole('img', { name: /Defy death/i })).toBeInTheDocument()
 
     expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('should render a Ribbon', () => {
+    renderWithTheme(
+      <Banner
+        {...props}
+        ribbonLabel="My Ribbon"
+        ribbonSize="small"
+        ribbonColor="secondary"
+      />
+    )
+
+    const ribbon = screen.getByText(/My Ribbon/i)
+
+    expect(ribbon).toBeInTheDocument()
+    expect(ribbon).toHaveStyle({ backgroundColor: '#3CD3C1' })
+    expect(ribbon).toHaveStyle({ height: '2.6rem', fontSize: '1.2rem' })
   })
 })


### PR DESCRIPTION
## 📝 Summary
This pull request introduces the integration of the Ribbon component into the Banner component. The integration was built using TDD, ensuring reliability and consistency with all supported variations of ribbon label, color, and size.

## ✨ Changes Made
- 🔗 Integration of Ribbon into Banner:

  - Displays a ribbon on the top-left corner of the banner when provided;

  - Accepts the following Ribbon props:

    - children (label text);

    - color (primary or secondary);

    - size (small or normal).

- 🧪 Test Coverage: 

  - Added tests to validate the presence and rendering of the Ribbon inside the Banner;

  - Ensured tests handle different size and color scenarios

- 📚 Storybook Updates:

  - Updated Banner stories to include variations using the Ribbon;

  - Clearly demonstrates the combination of both components under different visual states.

## 🎥 Preview

| Desktop Layout | Mobile Layout | 
| -- | -- | 
| ![image](https://github.com/user-attachments/assets/3696d889-60e1-4e97-8c88-cb80fe195196) | ![image](https://github.com/user-attachments/assets/8e4974a8-0bf9-41f8-8ea7-5fadd079e650) | 
